### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,6 @@
+name        := "ruby"
+description := "An interpreted object-oriented programming language often used for web development."
+gitrepo     := "https://github.com/ruby/ruby.git"
+homepage    := "https://www.ruby-lang.org/en/"
+license     := "BSD-2-Clause"
+version     := 2.6.0 sha256:9f64a71ad1efa20aed4451e798772893479ea00cb0a131777f2c9b71cc75df59 https://github.com/ruby/ruby/archive/ruby_2_6.tar.gz


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

